### PR TITLE
add missing paren to example.clj

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ response body is currently not supported.
               [ion-provider.datomic]
               [ring.util.response :as ring-resp]
               [datomic.client.api :as d]
-              [datomic.ion.lambda.api-gateway :as apig])
+              [datomic.ion.lambda.api-gateway :as apig]))
 
 ;; Routes elided
 (def routes ...)


### PR DESCRIPTION
Add missing paren making it easier to copy and paste the example into a par-edit environment like Cursive.